### PR TITLE
fix crop area escape through top image border

### DIFF
--- a/src/ReactCrop.tsx
+++ b/src/ReactCrop.tsx
@@ -138,7 +138,12 @@ function containCrop(prevCrop: Partial<Crop>, crop: Partial<Crop>, imageWidth: n
 
   let adjustedForY = false;
 
-  if (pixelCrop.y + pixelCrop.height > imageHeight) {
+  if (pixelCrop.y < 0) {
+    pixelCrop.y = 0;
+    pixelCrop.height +=  pixelCrop.y;
+    pixelCrop.width = pixelCrop.height * pixelCrop.aspect;
+    adjustedForX = true;
+  } else if (pixelCrop.y + pixelCrop.height > imageHeight) {
     pixelCrop.height = imageHeight - pixelCrop.y;
     pixelCrop.width = pixelCrop.height * pixelCrop.aspect;
     adjustedForY = true;


### PR DESCRIPTION
I recently opened an issue #465 about this bug and i rely on this lib, so i tried to fix it by myself. Check it pls 😃 