### PR TITLE
Fix visibility of crop mask with empty crop

### DIFF
--- a/src/ReactCrop.scss
+++ b/src/ReactCrop.scss
@@ -126,6 +126,7 @@ $mobile-media-query: '(pointer: coarse)' !default;
       outline-offset: -1px;
     }
   }
+  &--invisible-crop &__crop-mask,
   &--invisible-crop &__crop-selection {
     display: none;
   }


### PR DESCRIPTION
Updates styling so that the crop mask (`.ReactCrop__crop-mask`) is hidden, like the crop selection is, with an empty crop object (when the `ReactCrop--invisible-crop` CSS class is active).

Fixes #575