### PR TITLE
fix(#601): changes dts plugin to merge all types files into single file

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,6 +38,10 @@ export default defineConfig({
     react({
       jsxRuntime: 'classic',
     }),
-    dts(),
+    dts({
+      staticImport: true,
+      insertTypesEntry: true,
+      rollupTypes: true,
+    }),
   ],
 })


### PR DESCRIPTION
This pull request configures vite-plugin-dts to generate a single type file "solving" the problem of importing files with tsconfig setting as moduleResolution: "nodeNext".

![image](https://github.com/user-attachments/assets/16bf7924-999f-4694-9186-a3f088706cfb)

Please let me know if this breaks compatibility with different setups and I'll try another approach.